### PR TITLE
Fastboot fix

### DIFF
--- a/addon/components/sortable-group.js
+++ b/addon/components/sortable-group.js
@@ -25,15 +25,18 @@ export default Component.extend({
     },
     init() {
         //Default sortable group array to be null, these will be added when the sortable groups insert into the DOM
-        const sortable = new Sortable([], {
-            draggable: '.sortable-item',
-            mirror: {
-                constrainDimensions: true
-            },
-            plugins: [Plugins.ResizeMirror]
-        });
-        set(this, 'sortable', sortable);
-        this.initializeEventListeners();
+        if (!get(this, 'fastboot.isFastBoot')) {
+            const sortable = new Sortable([], {
+                draggable: '.sortable-item',
+                mirror: {
+                    constrainDimensions: true
+                },
+                plugins: [Plugins.ResizeMirror]
+            });
+            set(this, 'sortable', sortable);
+            this.initializeEventListeners();
+        }
+
         this._super(...arguments);
     },
     willDestroyElement() {

--- a/addon/components/sortable-group.js
+++ b/addon/components/sortable-group.js
@@ -29,9 +29,8 @@ export default Component.extend({
         });
     },
     init() {
-        const fastboot = get(this, 'fastboot');
         //Default sortable group array to be null, these will be added when the sortable groups insert into the DOM
-        if (!fastboot || get(fastboot, 'isFastBoot') === false) {
+        if (!get(this, 'fastboot.isFastBoot')) {
             const sortable = new Sortable([], {
                 draggable: '.sortable-item',
                 mirror: {

--- a/addon/components/sortable-group.js
+++ b/addon/components/sortable-group.js
@@ -1,9 +1,10 @@
 import Component from '@ember/component';
 import { Sortable, Plugins } from 'draggable';
 import layout from '../templates/components/sortable-group';
-import { get, set } from '@ember/object';
+import { get, set, computed } from '@ember/object';
 import { tryInvoke } from '@ember/utils';
 import { A } from '@ember/array';
+import { getOwner } from '@ember/application';
 
 export default Component.extend({
     layout,
@@ -15,6 +16,10 @@ export default Component.extend({
         'start',
         'stop'
     ]),
+    fastboot: computed(function() {
+        let owner = getOwner(this);
+        return owner.lookup('service:fastboot');
+    }),
     initializeEventListeners() {
         const sortable = get(this, 'sortable');
         get(this, 'events').forEach(eventName => {
@@ -24,8 +29,9 @@ export default Component.extend({
         });
     },
     init() {
+        const fastboot = get(this, 'fastboot');
         //Default sortable group array to be null, these will be added when the sortable groups insert into the DOM
-        if (!get(this, 'fastboot.isFastBoot')) {
+        if (!fastboot || get(fastboot, 'isFastBoot') === false) {
             const sortable = new Sortable([], {
                 draggable: '.sortable-item',
                 mirror: {

--- a/addon/components/swappable-group.js
+++ b/addon/components/swappable-group.js
@@ -29,9 +29,8 @@ export default Component.extend({
         });
     },
     init() {
-        const fastboot = get(this, 'fastboot');
         //Default swappable group array to be null, these will be added when the sortable groups insert into the DOM
-        if (!fastboot || get(fastboot, 'isFastBoot') === false) {
+        if (!get(this, 'fastboot.isFastBoot')) {
             const swappable = new Swappable([], {
                 draggable: '.swappable-item',
                 mirror: {

--- a/addon/components/swappable-group.js
+++ b/addon/components/swappable-group.js
@@ -1,9 +1,10 @@
 import Component from '@ember/component';
 import { Swappable, Plugins } from 'draggable';
 import layout from '../templates/components/swappable-group';
-import { get, set } from '@ember/object';
+import { get, set, computed } from '@ember/object';
 import { A } from '@ember/array';
 import { tryInvoke } from '@ember/utils';
+import { getOwner } from '@ember/application';
 
 export default Component.extend({
     layout,
@@ -15,6 +16,10 @@ export default Component.extend({
         'start',
         'stop'
     ]),
+    fastboot: computed(function() {
+        let owner = getOwner(this);
+        return owner.lookup('service:fastboot');
+    }),
     initializeEventListeners() {
         const swappable = get(this, 'swappable');
         get(this, 'events').forEach(eventName => {
@@ -24,8 +29,9 @@ export default Component.extend({
         });
     },
     init() {
+        const fastboot = get(this, 'fastboot');
         //Default swappable group array to be null, these will be added when the sortable groups insert into the DOM
-        if (!get(this, 'fastboot.isFastBoot')) {
+        if (!fastboot || get(fastboot, 'isFastBoot') === false) {
             const swappable = new Swappable([], {
                 draggable: '.swappable-item',
                 mirror: {

--- a/addon/components/swappable-group.js
+++ b/addon/components/swappable-group.js
@@ -25,15 +25,18 @@ export default Component.extend({
     },
     init() {
         //Default swappable group array to be null, these will be added when the sortable groups insert into the DOM
-        const swappable = new Swappable([], {
-            draggable: '.swappable-item',
-            mirror: {
-                constrainDimensions: true
-            },
-            plugins: [Plugins.ResizeMirror]
-        });
-        set(this, 'swappable', swappable);
-        this.initializeEventListeners();
+        if (!get(this, 'fastboot.isFastBoot')) {
+            const swappable = new Swappable([], {
+                draggable: '.swappable-item',
+                mirror: {
+                    constrainDimensions: true
+                },
+                plugins: [Plugins.ResizeMirror]
+            });
+            set(this, 'swappable', swappable);
+            this.initializeEventListeners();
+        }
+
         this._super(...arguments);
     },
     willDestroyElement() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-shopify-draggable",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Fixes fastboot error now that we are using `init` (which does get run in fastboot). We were previously using `didInsertElement` which is why we were not seeing this error before .. since that does NOT get run in fastboot