### PR TITLE
Set repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "ember-addon"
   ],
-  "repository": "",
+  "repository": "https://github.com/Gavant/ember-shopify-draggable",
   "license": "MIT",
   "author": "",
   "directories": {


### PR DESCRIPTION
This lets sites like Ember Observer get additional information about this addon.